### PR TITLE
Fix TSL with params on paper

### DIFF
--- a/src/core/mapping.rs
+++ b/src/core/mapping.rs
@@ -209,8 +209,9 @@ pub fn integer_to_vertex(
             sum_before = sum_including;
 
             if j == j_max {
-                // x_i is beyond valid range
-                return Err(MappingError::IndexOutOfRange { index: x, max: 0, },);
+                // x_i is beyond valid range, use actual layer size if available
+                let max_size = layer_size_big.to_usize().unwrap_or(usize::MAX);
+                return Err(MappingError::IndexOutOfRange { index: x, max: max_size, },);
             }
         }
 
@@ -238,7 +239,8 @@ pub fn integer_to_vertex(
 
     // Set a_v := w - x_v - d_v
     if x_i + d_i > w {
-        return Err(MappingError::IndexOutOfRange { index: x, max: 0, },);
+        let max_size = layer_size_big.to_usize().unwrap_or(usize::MAX);
+        return Err(MappingError::IndexOutOfRange { index: x, max: max_size, },);
     }
     vertex[v - 1] = w - x_i - d_i;
 

--- a/src/schemes/tsl.rs
+++ b/src/schemes/tsl.rs
@@ -458,4 +458,24 @@ mod tests {
         let layer = Hypercube::new(w, v,).calculate_layer(&encoded,);
         assert_eq!(layer, 168); // Should be in layer d0 = 168
     }
+
+    #[test]
+    fn test_tsl_encoding_paper_params_4() { // minimum params on the paper
+        let w = 56;
+        let v = 35;
+        let d0 = 337;
+
+        let config = TSLConfig::with_params(w, v, d0); // Small example for testing
+        let tsl = TSL::new(config,);
+
+        // Test encoding
+        let message = b"test message";
+        let randomness = b"random seed";
+
+        let encoded = tsl.encode(message, randomness,).unwrap();
+
+        // Verify the encoded vertex is in the correct layer
+        let layer = Hypercube::new(w, v,).calculate_layer(&encoded,);
+        assert_eq!(layer, 337); // Should be in layer d0 = 337
+    }
 }

--- a/src/schemes/tsl.rs
+++ b/src/schemes/tsl.rs
@@ -380,4 +380,44 @@ mod tests {
         let layer = Hypercube::new(w, v,).calculate_layer(&encoded,);
         assert_eq!(layer, 384); // Should be in layer d0 = 384
     }
+
+    #[test]
+    fn test_tsl_encoding_paper_params_2() { // minimum params on the paper
+        let w = 44;
+        let v = 30;
+        let d0 = 235;
+
+        let config = TSLConfig::with_params(w, v, d0); // Small example for testing
+        let tsl = TSL::new(config,);
+
+        // Test encoding
+        let message = b"test message";
+        let randomness = b"random seed";
+
+        let encoded = tsl.encode(message, randomness,).unwrap();
+
+        // Verify the encoded vertex is in the correct layer
+        let layer = Hypercube::new(w, v,).calculate_layer(&encoded,);
+        assert_eq!(layer, 235); // Should be in layer d0 = 235
+    }
+
+    #[test]
+    fn test_tsl_encoding_paper_params_3() { // minimum params on the paper
+        let w = 26;
+        let v = 35;
+        let d0 = 168;
+
+        let config = TSLConfig::with_params(w, v, d0); // Small example for testing
+        let tsl = TSL::new(config,);
+
+        // Test encoding
+        let message = b"test message";
+        let randomness = b"random seed";
+
+        let encoded = tsl.encode(message, randomness,).unwrap();
+
+        // Verify the encoded vertex is in the correct layer
+        let layer = Hypercube::new(w, v,).calculate_layer(&encoded,);
+        assert_eq!(layer, 168); // Should be in layer d0 = 168
+    }
 }

--- a/src/schemes/tsl.rs
+++ b/src/schemes/tsl.rs
@@ -348,4 +348,24 @@ mod tests {
 
         assert_eq!(config.signature_chains(), 32); // Only v chains, no checksum
     }
+
+    #[test]
+    fn test_tsl_encoding_paper_params_1() { // minimum params on the paper
+        let w = 86;
+        let v = 25;
+        let d0 = 384;
+
+        let config = TSLConfig::with_params(w, v, d0); // Small example for testing
+        let tsl = TSL::new(config,);
+
+        // Test encoding
+        let message = b"test message";
+        let randomness = b"random seed";
+
+        let encoded = tsl.encode(message, randomness,).unwrap();
+
+        // Verify the encoded vertex is in the correct layer
+        let layer = Hypercube::new(w, v,).calculate_layer(&encoded,);
+        assert_eq!(layer, 384); // Should be in layer d0 = 384
+    }
 }


### PR DESCRIPTION
論文内で提示されているパラメータの小さいもの4組を用いたテストを書き、それが通るよう型周りを修正しました。
